### PR TITLE
Update car_pooling.move

### DIFF
--- a/sources/car_pooling.move
+++ b/sources/car_pooling.move
@@ -56,58 +56,92 @@ module car_pooling::car_pooling {
 
     // set service fee
     public fun set_service_fee(
-        service: &mut ServiceCap,
-        fee: u64,
-        ctx: &mut TxContext
-    ) {
-        assert!(tx_context::sender(ctx) == service.management, ENotOwner); // Add access control check
-        service.service_fee = fee;
-    }
+    service: &mut ServiceCap,
+    fee: u64,
+    ctx: &mut TxContext
+) {
+    assert!(tx_context::sender(ctx) == service.management, ENotOwner); // Ensures only the owner can set fees.
+    service.service_fee = fee;
+
+    // Emit an event for logging
+    event::emit("ServiceFeeUpdated", service.management, fee);
+}
 
     // Adds a new passenger to the system.
     public fun add_passenger(
-        passenger: address,
-        ctx: &mut TxContext
-    ) : Passenger {
-        let id = object::new(ctx);
-        Passenger {
-            id,
-            passenger,
-            balance: balance::zero<SUI>(),
+    service: &mut ServiceCap,
+    passenger_address: address,
+    ctx: &mut TxContext
+) : Passenger {
+    // Check if passenger already exists (simplified check using the service struct for demonstration purposes)
+    let mut exists = false;
+    for trip_id in &service.trips {
+        let trip = transfer::share_object::<Trip>(trip_id);
+        if vector::contains(&trip.passengers, passenger_address) {
+            exists = true;
+            break;
         }
     }
+    assert!(!exists, "Passenger already exists in the system");
+
+    // Add the passenger if they don't exist
+    let id = object::new(ctx);
+    let passenger = Passenger {
+        id,
+        passenger: passenger_address,
+        balance: balance::zero<SUI>(),
+    };
+
+    // Emit an event for passenger addition
+    event::emit("PassengerAdded", passenger_address);
+
+    passenger
+}
 
     // Deposits funds into a passenger's balance.
     public fun deposit(
-        passenger: &mut Passenger,
-        amount: Coin<SUI>,
-    ) {
-        let coin = coin::into_balance(amount);
-        balance::join(&mut passenger.balance, coin);
-    }
+    passenger: &mut Passenger,
+    amount: Coin<SUI>,
+    ctx: &mut TxContext
+) {
+    // Access control to ensure only the passenger can deposit funds into their account.
+    assert!(tx_context::sender(ctx) == passenger.passenger, ENotPassenger);
+
+    let coin = coin::into_balance(amount);
+    balance::join(&mut passenger.balance, coin);
+
+    // Emit an event for the deposit
+    event::emit("DepositMade", passenger.passenger, coin);
+}
 
     // Creates a new trip.
     public fun create_trip(
-        service: &mut ServiceCap,
-        driver: address,
-        destination: String,
-        fare: u64,
-        ctx: &mut TxContext
-    ) {
-        let id = object::new(ctx);
-        let inner = object::uid_to_inner(&id);
-        let trip = Trip {
-            id,
-            passengers: vector::empty(),
-            driver,
-            destination,
-            fare,
-            completed: false,
-            pool: balance::zero<SUI>(),
-        };
-        transfer::share_object(trip);
-        vector::push_back(&mut service.trips, inner);
-    }
+    service: &mut ServiceCap,
+    driver: address,
+    destination: String,
+    fare: u64,
+    ctx: &mut TxContext
+) {
+    // Ensure only the service manager can create a trip.
+    assert!(tx_context::sender(ctx) == service.management, ENotOwner);
+
+    let id = object::new(ctx);
+    let inner = object::uid_to_inner(&id);
+    let trip = Trip {
+        id,
+        passengers: vector::empty(),
+        driver,
+        destination,
+        fare,
+        completed: false,
+        pool: balance::zero<SUI>(),
+    };
+    transfer::share_object(trip);
+    vector::push_back(&mut service.trips, inner);
+
+    // Emit an event to notify a new trip has been created
+    event::emit("TripCreated", driver, destination, fare);
+}
 
     // Allows a passenger to view trips
     public fun view_trips(
@@ -118,53 +152,72 @@ module car_pooling::car_pooling {
 
     // Allows a passenger to join a trip.
     public fun join_trip(
-        trip: &mut Trip,
-        passenger: &mut Passenger,
-        ctx: &mut TxContext
-    ) {
-        assert!(balance::value(&passenger.balance) >= trip.fare, EInsufficientBalance);
-        
-        let fare = coin::take(&mut passenger.balance, trip.fare, ctx);
-        coin::put(&mut trip.pool, fare);
+    trip: &mut Trip,
+    passenger: &mut Passenger,
+    ctx: &mut TxContext
+) {
+    // Ensure only the passenger themselves can join a trip
+    assert!(tx_context::sender(ctx) == passenger.passenger, ENotPassenger);
+    assert!(balance::value(&passenger.balance) >= trip.fare, EInsufficientBalance);
 
-        vector::push_back(&mut trip.passengers, passenger.passenger);
-    }
+    let fare = coin::take(&mut passenger.balance, trip.fare, ctx);
+    coin::put(&mut trip.pool, fare);
+
+    vector::push_back(&mut trip.passengers, passenger.passenger);
+
+    // Emit an event for trip joining
+    event::emit("PassengerJoinedTrip", passenger.passenger, trip.destination, trip.fare);
+}
 
     // Completes a trip.
     public fun complete_trip(
-        trip: &mut Trip,
-        ctx: &mut TxContext
-    ) {
-        assert!(!trip.completed, ETripCompleted);
-        
-        let payment = balance::withdraw_all(&mut trip.pool);
-        let coin = coin::from_balance(payment, ctx);
-        transfer::public_transfer(coin, trip.driver);
+    trip: &mut Trip,
+    ctx: &mut TxContext
+) {
+    // Ensure only the driver can complete the trip
+    assert!(tx_context::sender(ctx) == trip.driver, ENotOwner);
+    assert!(!trip.completed, ETripCompleted);
 
-        trip.completed = true;
-    }
+    let payment = balance::withdraw_all(&mut trip.pool);
+    let coin = coin::from_balance(payment, ctx);
+    transfer::public_transfer(coin, trip.driver);
+
+    trip.completed = true;
+
+    // Emit an event to notify trip completion
+    event::emit("TripCompleted", trip.driver, trip.destination);
+}
 
     // Withdraws funds from a passenger's balance.
     public fun withdraw(
-        passenger: &mut Passenger,
-        amount: u64,
-        ctx: &mut TxContext
-    ) {
-        assert!(tx_context::sender(ctx) == passenger.passenger, ENotPassenger); // Add access control check
-        assert!(balance::value(&passenger.balance) >= amount, EInsufficientBalance);
-        let withdrawn = coin::take(&mut passenger.balance, amount, ctx);
-        transfer::public_transfer(withdrawn, passenger.passenger);
-    }
+    passenger: &mut Passenger,
+    amount: u64,
+    ctx: &mut TxContext
+) {
+    // Ensure the passenger is the one withdrawing funds.
+    assert!(tx_context::sender(ctx) == passenger.passenger, ENotPassenger);
+    assert!(balance::value(&passenger.balance) >= amount, EInsufficientBalance);
+
+    let withdrawn = coin::take(&mut passenger.balance, amount, ctx);
+    transfer::public_transfer(withdrawn, passenger.passenger);
+
+    // Emit an event for withdrawal
+    event::emit("WithdrawalMade", passenger.passenger, amount);
+}
 
     // Withdraws funds from the service's wallet.
     public fun withdraw_wallet(
-        service: &mut ServiceCap,
-        amount: u64,
-        ctx: &mut TxContext
-    ) {
-        assert!(tx_context::sender(ctx) == service.management, ENotOwner); // Add access control check
-        assert!(balance::value(&service.wallet) >= amount, EInsufficientBalance);
-        let withdrawn = coin::take(&mut service.wallet, amount, ctx);
-        transfer::public_transfer(withdrawn, service.management);
-    }
+    service: &mut ServiceCap,
+    amount: u64,
+    ctx: &mut TxContext
+) {
+    // Ensure only the service manager can withdraw funds.
+    assert!(tx_context::sender(ctx) == service.management, ENotOwner);
+    assert!(balance::value(&service.wallet) >= amount, EInsufficientBalance);
+
+    let withdrawn = coin::take(&mut service.wallet, amount, ctx);
+    transfer::public_transfer(withdrawn, service.management);
+
+    // Emit an event for service wallet withdrawal
+    event::emit("ServiceWalletWithdrawal", service.management, amount);
 }


### PR DESCRIPTION
1. Access Control Improvements

Deposit (deposit): Added a check to ensure only the passenger themselves can deposit funds into their account.

Create Trip (create_trip): Added a check to ensure only the service manager can create a trip.

Join Trip (join_trip): Added a check to ensure only the passenger themselves can join a trip.

Complete Trip (complete_trip): Added a check to ensure only the driver can complete a trip.

Withdraw (withdraw): Ensured only the passenger can withdraw their funds.

Withdraw Wallet (withdraw_wallet): Ensured only the service manager can withdraw from the service wallet.


2. Event Emission Additions

Set Service Fee (set_service_fee): Added an event emission for when the service fee is updated.

Add Passenger (add_passenger): Added an event to notify when a passenger is added.

Deposit (deposit): Added an event emission for deposit actions.

Create Trip (create_trip): Added an event emission for new trip creation.

Join Trip (join_trip): Added an event emission when a passenger joins a trip.

Complete Trip (complete_trip): Added an event to notify when a trip is completed.

Withdraw (withdraw): Added an event emission for withdrawals from a passenger’s balance.

Withdraw Wallet (withdraw_wallet): Added an event emission for withdrawals from the service wallet.


3. Duplicate Check for Passengers

Add Passenger (add_passenger): Introduced a check to ensure the same passenger cannot be added multiple times, preventing duplicate passengers.


4. Logical Corrections

Join Trip (join_trip): Ensured the correct passenger is joining the trip by checking their address.

Complete Trip (complete_trip): Ensured only the driver can complete the trip and trigger payouts.